### PR TITLE
Added android SDK to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,11 @@
 # -- MISCELLANEOUS -------------------------
-*.DS_STORE
+*.DS_Store
 
 # Intentionally excluding the BlinkUp SDK from this repository
 *BlinkUp.framework
 *BlinkUp.bundle
 *BlinkUp.embeddedframework
-*/blinkup_sdk
+**/blinkup_sdk/
 
 # -- OBJECTIVE-C -----------------------
 # https://github.com/github/gitignore/blob/master/Objective-C.gitignore


### PR DESCRIPTION
Previous entry of `*/blinkup_sdk` wasn't working, so used `platforms/android/blinkup_sdk` as the file must be there as that's where gradle looks for it.
