### PR TITLE
iOS sample. Removed the SDK build phase entirely.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,11 @@ A BlinkUp SDK and API Key. For more information on how to obtain a license, plea
 **Both Platforms**<br>
 Run the `SetApiKey.sh` script with your BlinkUp API key as an argument. E.g: `./SetApiKey.sh this_is_my_api_key`.
 
-**iOS**<br>
-Open `platforms/ios/CordovaBlinkUp.xcodeproj` in Xcode and select the Frameworks group in project navigator. Choose File > Add Files and select the `BlinkUp.framework` file included in the BlinkUp SDK, making sure "Copy items if needed" is selected. Do the same for `BlinkUp.bundle`, found in `BlinkUp.framework/resources/versions/A`. 
+**iOS Instructions**<br>
+Copy the `BlinkUp.embeddedframework` folder to `path/to/Cordova-BlinkUpSample/platforms/ios/CordovaBlinkUpSample/Frameworks` folder.
 
-If you wish to link to these resources without copying them into the project directory, you will need to remove "Check For BlinkUp SDK" from the Xcode project's build phases.
-
-**Android**<br>
-Copy the `blinkup_sdk` folder from the BlinkUp SDK to `path/to/project/platforms/android`. 
+**Android Instructions**<br>
+Copy the `blinkup_sdk` folder from the BlinkUp SDK to `path/to/Cordova-BlinkUpSample/platforms/android`. 
 
 # Project Structure
 Refer to `www/index.js` for an example of how to call the plugin that initiates the native BlinkUp process. 

--- a/platforms/ios/CordovaBlinkUpSample.xcodeproj/project.pbxproj
+++ b/platforms/ios/CordovaBlinkUpSample.xcodeproj/project.pbxproj
@@ -286,7 +286,6 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 1D6058960D05DD3E006BFB54 /* Build configuration list for PBXNativeTarget "CordovaBlinkUpSample" */;
 			buildPhases = (
-				A6F5B1411B29CDCE009AC5FF /* Check For BlinkUp SDK */,
 				304B58A110DAC018002A0835 /* Copy www directory */,
 				1D60588D0D05DD3D006BFB54 /* Resources */,
 				1D60588E0D05DD3D006BFB54 /* Sources */,
@@ -401,21 +400,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "cordova/lib/copy-www-build-step.sh";
-			showEnvVarsInLog = 0;
-		};
-		A6F5B1411B29CDCE009AC5FF /* Check For BlinkUp SDK */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Check For BlinkUp SDK";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "if [ -e \"CordovaBlinkUpSample/Frameworks/BlinkUp.framework\" ]; then\nosascript -e 'display dialog \"BlinkUp.framework could not be found in platforms/ios/CordovaBlinkUpSample/Frameworks. Ensure that you have copied the file to that location.\\n\\nIf you do not own the BlinkUp SDK, you may send a request to sales@electricimp.com\" buttons \"OK\" default button 1 with title \"Cannot Locate BlinkUp Framework\" with icon stop'\nexit 1\nfi\n\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */


### PR DESCRIPTION
Given that the files are included as part of the project structure, if a developer builds the sample application without providing the BlinkUp SDK, there will be a clear build failure. Removing the Build Phase that checks it explicitly.

Updated the Readme accordingly.
