### PR TITLE
Android's Globals class now uses getInstance() method

### DIFF
--- a/platforms/android/src/com/macadamian/blinkup/BlinkUpCompleteActivity.java
+++ b/platforms/android/src/com/macadamian/blinkup/BlinkUpCompleteActivity.java
@@ -46,12 +46,12 @@ public class BlinkUpCompleteActivity extends Activity {
         // send callback that we're waiting on server
         JSONObject resultJSON = new JSONObject();
         try {
-            resultJSON.put(Globals.STATUS_KEY, "Gathering device info...");
-            resultJSON.put(Globals.GATHERING_DEVICE_INFO_KEY, "true");
+            resultJSON.put(Globals.getInstance().STATUS_KEY, "Gathering device info...");
+            resultJSON.put(Globals.getInstance().GATHERING_DEVICE_INFO_KEY, "true");
 
             PluginResult pluginResult = new PluginResult(PluginResult.Status.OK, resultJSON.toString());
             pluginResult.setKeepCallback(true);
-            Globals.callbackContext.sendPluginResult(pluginResult);
+            Globals.getInstance().callbackContext.sendPluginResult(pluginResult);
         } catch (JSONException e) {
             Log.e("BlinkUpPlugin","JSON Exception: " + e.toString());
         }
@@ -71,21 +71,21 @@ public class BlinkUpCompleteActivity extends Activity {
                     String agentURL = json.getString("agent_url");
 
                     JSONObject resultJSON = new JSONObject();
-                    resultJSON.put(Globals.STATUS_KEY, "Device Connected");
-                    resultJSON.put(Globals.GATHERING_DEVICE_INFO_KEY, "false");
-                    resultJSON.put(Globals.PLAN_ID_KEY, json.getString("plan_id"));
-                    resultJSON.put(Globals.DEVICE_ID_KEY, deviceId);
-                    resultJSON.put(Globals.AGENT_URL_KEY, agentURL);
+                    resultJSON.put(Globals.getInstance().STATUS_KEY, "Device Connected");
+                    resultJSON.put(Globals.getInstance().GATHERING_DEVICE_INFO_KEY, "false");
+                    resultJSON.put(Globals.getInstance().PLAN_ID_KEY, json.getString("plan_id"));
+                    resultJSON.put(Globals.getInstance().DEVICE_ID_KEY, deviceId);
+                    resultJSON.put(Globals.getInstance().AGENT_URL_KEY, agentURL);
 
                     // cache planID (see electricimp.com/docs/manufacturing/planids/)
                     SharedPreferences preferences = getSharedPreferences("DefaultPreferences", MODE_PRIVATE);
                     SharedPreferences.Editor editor = preferences.edit();
-                    editor.putString(Globals.PLAN_ID_KEY, json.getString("plan_id"));
+                    editor.putString(Globals.getInstance().PLAN_ID_KEY, json.getString("plan_id"));
                     editor.apply();
 
                     PluginResult pluginResult = new PluginResult(PluginResult.Status.OK, resultJSON.toString());
                     pluginResult.setKeepCallback(true);
-                    Globals.callbackContext.sendPluginResult(pluginResult);
+                    Globals.getInstance().callbackContext.sendPluginResult(pluginResult);
                 }
                 catch (JSONException e) {
                     Log.e("BlinkUpPlugin", e.getMessage());
@@ -98,7 +98,7 @@ public class BlinkUpCompleteActivity extends Activity {
             @Override public void onError(String errorMsg) {
                 PluginResult pluginResult = new PluginResult(PluginResult.Status.ERROR, ("Error. " + errorMsg));
                 pluginResult.setKeepCallback(true);
-                Globals.callbackContext.sendPluginResult(pluginResult);
+                Globals.getInstance().callbackContext.sendPluginResult(pluginResult);
             }
 
             //---------------------------------
@@ -110,6 +110,6 @@ public class BlinkUpCompleteActivity extends Activity {
         };
 
         // request the device info from the server
-        Globals.blinkUpController.getTokenStatus(tokenStatusCallback, Globals.timeoutMs);
+        Globals.getInstance().blinkUpController.getTokenStatus(tokenStatusCallback, Globals.getInstance().timeoutMs);
     }
 }

--- a/platforms/android/src/com/macadamian/blinkup/BlinkUpPlugin.java
+++ b/platforms/android/src/com/macadamian/blinkup/BlinkUpPlugin.java
@@ -34,7 +34,7 @@ import org.apache.cordova.*;
  ********************************************/
 public class BlinkUpPlugin extends CordovaPlugin {
 
-    // Only needed in this class, so not in Globals
+    // Only needed in this class, so not in Globals.getInstance()
     private String apiKey;
     private Boolean useCachedPlanId = false;
 
@@ -45,10 +45,10 @@ public class BlinkUpPlugin extends CordovaPlugin {
     public boolean execute(String action, JSONArray data, CallbackContext callbackContext) throws JSONException {
         if (action.equalsIgnoreCase("invokeBlinkUp")) {
 
-            Globals.callbackContext = callbackContext;
+            Globals.getInstance().callbackContext = callbackContext;
             try {
                 this.apiKey = data.getString(0);
-                Globals.timeoutMs = data.getInt(1);
+                Globals.getInstance().timeoutMs = data.getInt(1);
                 this.useCachedPlanId = data.getBoolean(2);
             } catch (JSONException exc) {
                 String error = "Error. Invalid argument count in call to invoke blink up (apiKey: String, timeoutMs: Integer, useCachedPlanId: Bool, success: Callback, failure: Callback)";
@@ -83,7 +83,7 @@ public class BlinkUpPlugin extends CordovaPlugin {
                 if (s.contains("401")) {
                     String errorMsg = "Error. Invalid API key. You must set your BlinkUp API key using the SetApiKey.sh script. See README.md for more details.";
                     Toast.makeText(cordova.getActivity(), errorMsg, Toast.LENGTH_LONG).show();
-                    Globals.callbackContext.error(errorMsg);
+                    Globals.getInstance().callbackContext.error(errorMsg);
                 }
                 else {
                     Toast.makeText(cordova.getActivity(), ("Error. " + s), Toast.LENGTH_SHORT).show();
@@ -95,34 +95,34 @@ public class BlinkUpPlugin extends CordovaPlugin {
         BlinkupController.ServerErrorHandler serverErrorHandler= new BlinkupController.ServerErrorHandler() {
             @Override
             public void onError(String s) {
-                Globals.callbackContext.error("Error. Could not verify API key with Electric Imp servers.");
+                Globals.getInstance().callbackContext.error("Error. Could not verify API key with Electric Imp servers.");
             }
         };
 
         // initialize controller
-        Globals.blinkUpController = BlinkupController.getInstance();
+        Globals.getInstance().blinkUpController = BlinkupController.getInstance();
 
         // load cached planId if available. Otherwise, SDK generates new one automatically
         if (this.useCachedPlanId) {
             SharedPreferences preferences = this.cordova.getActivity().getSharedPreferences("DefaultPreferences", this.cordova.getActivity().MODE_PRIVATE);
-            String planId = preferences.getString(Globals.PLAN_ID_KEY, null);
-            Globals.blinkUpController.setPlanID(planId);
+            String planId = preferences.getString(Globals.getInstance().PLAN_ID_KEY, null);
+            Globals.getInstance().blinkUpController.setPlanID(planId);
         }
 
         // set developerPlanId here to see device in Electric Imp IDE if in Debug Mode
         // see electricimp.com/docs/manufacturing/planids/ for info about planIDs
         if (org.apache.cordova.BuildConfig.DEBUG) {
             String developerPlanId = null;
-            Globals.blinkUpController.setPlanID(developerPlanId);
+            Globals.getInstance().blinkUpController.setPlanID(developerPlanId);
         }
 
-        Globals.blinkUpController.acquireSetupToken(this.cordova.getActivity(), this.apiKey, tokenAcquireCallback);
+        Globals.getInstance().blinkUpController.acquireSetupToken(this.cordova.getActivity(), this.apiKey, tokenAcquireCallback);
 
         // onActivityResult called on MainActivity (i.e. cordova.getActivity()) when blinkup or clear
         // complete. It calls handleActivityResult on blinkupController, which initiates the following intents
-        Globals.blinkUpController.intentBlinkupComplete = new Intent(this.cordova.getActivity(), BlinkUpCompleteActivity.class);
-        Globals.blinkUpController.intentClearComplete = new Intent(this.cordova.getActivity(), ClearCompleteActivity.class);
+        Globals.getInstance().blinkUpController.intentBlinkupComplete = new Intent(this.cordova.getActivity(), BlinkUpCompleteActivity.class);
+        Globals.getInstance().blinkUpController.intentClearComplete = new Intent(this.cordova.getActivity(), ClearCompleteActivity.class);
 
-        Globals.blinkUpController.selectWifiAndSetupDevice(this.cordova.getActivity(), this.apiKey, serverErrorHandler);
+        Globals.getInstance().blinkUpController.selectWifiAndSetupDevice(this.cordova.getActivity(), this.apiKey, serverErrorHandler);
     }
 }

--- a/platforms/android/src/com/macadamian/blinkup/ClearCompleteActivity.java
+++ b/platforms/android/src/com/macadamian/blinkup/ClearCompleteActivity.java
@@ -33,7 +33,7 @@ public class ClearCompleteActivity extends Activity {
         super.onCreate(savedInstanceState);
 
         // send callback that we've cleared device
-        Globals.callbackContext.success("Wireless configuration cleared.");
+        Globals.getInstance().callbackContext.success("Wireless configuration cleared.");
 
         this.finish();
     }

--- a/platforms/android/src/com/macadamian/blinkup/Globals.java
+++ b/platforms/android/src/com/macadamian/blinkup/Globals.java
@@ -22,9 +22,12 @@ import com.electricimp.blinkup.BlinkupController;
 
 /**************************************
  * stores several objects required
- * by multiple classes in application
+ * by multiple classes in application,
+ * following Java singleton pattern
  *************************************/
-public class Globals {
+public final class Globals {
+    private static Globals instance = null;
+
     public static CallbackContext callbackContext;
     public static BlinkupController blinkUpController;
     public static int timeoutMs = 60000; // default is 1 minute
@@ -35,4 +38,15 @@ public class Globals {
     public static final String PLAN_ID_KEY = "planId";
     public static final String DEVICE_ID_KEY = "deviceId";
     public static final String AGENT_URL_KEY = "agentURL";
+
+    // ensure that no one else can initialize us
+    private Globals() { }
+
+    // ensures that we always get the same instance
+    public static Globals getInstance() {
+        if (instance == null) {
+            instance = new Globals();
+        }
+        return instance;
+    }
 }

--- a/platforms/android/src/com/macadamian/cordovaBlinkUpSample/MainActivity.java
+++ b/platforms/android/src/com/macadamian/cordovaBlinkUpSample/MainActivity.java
@@ -38,6 +38,6 @@ public class MainActivity extends CordovaActivity {
     // need to handle results when blinkup completes -- added by Stuart Douglas June 11, 2015
     protected void onActivityResult(int requestCode, int resultCode, Intent intent) {
         super.onActivityResult(requestCode, resultCode, intent);
-        Globals.blinkUpController.handleActivityResult(this, requestCode, resultCode, intent);
+        Globals.getInstance().blinkUpController.handleActivityResult(this, requestCode, resultCode, intent);
     }
 }


### PR DESCRIPTION
-this better follows the singleton pattern in java
-all the other files now access Globals through the static instance form getInstance()
-Globals seems like a necessary evil at this point, might as well make it as robust as possible
