### PR TITLE
use enums on android for status and error codes

### DIFF
--- a/platforms/android/src/com/macadamian/blinkup/BlinkUpCompleteActivity.java
+++ b/platforms/android/src/com/macadamian/blinkup/BlinkUpCompleteActivity.java
@@ -45,7 +45,7 @@ public class BlinkUpCompleteActivity extends Activity {
 
         BlinkUpPluginResult pluginResult = new BlinkUpPluginResult();
         pluginResult.setState(BlinkUpPluginResult.BlinkUpPluginState.Started);
-        pluginResult.setStatusCode(BlinkUpPlugin.GATHERING_INFO);
+        pluginResult.setStatusCode(BlinkUpPlugin.StatusCodes.GATHERING_INFO.getCode());
         pluginResult.sendResultsToCallback();
 
         this.finish();
@@ -60,7 +60,7 @@ public class BlinkUpCompleteActivity extends Activity {
             @Override public void onSuccess(JSONObject json) {
                 BlinkUpPluginResult pluginResult = new BlinkUpPluginResult();
                 pluginResult.setState(BlinkUpPluginResult.BlinkUpPluginState.Completed);
-                pluginResult.setStatusCode(BlinkUpPlugin.DEVICE_CONNECTED);
+                pluginResult.setStatusCode(BlinkUpPlugin.StatusCodes.DEVICE_CONNECTED.getCode());
                 pluginResult.setDeviceInfoAsJson(json);
                 pluginResult.sendResultsToCallback();
 
@@ -92,7 +92,7 @@ public class BlinkUpCompleteActivity extends Activity {
             @Override public void onTimeout() {
                 BlinkUpPluginResult pluginResult = new BlinkUpPluginResult();
                 pluginResult.setState(BlinkUpPluginResult.BlinkUpPluginState.Error);
-                pluginResult.setPluginError(BlinkUpPlugin.PROCESS_TIMED_OUT);
+                pluginResult.setPluginError(BlinkUpPlugin.ErrorCodes.PROCESS_TIMED_OUT.getCode());
                 pluginResult.sendResultsToCallback();
             }
         };

--- a/platforms/android/src/com/macadamian/blinkup/BlinkUpPlugin.java
+++ b/platforms/android/src/com/macadamian/blinkup/BlinkUpPlugin.java
@@ -43,20 +43,32 @@ public class BlinkUpPlugin extends CordovaPlugin {
     public static int timeoutMs = 60000;
     public static CallbackContext callbackContext;
 
+    public enum StatusCodes {
+        DEVICE_CONNECTED(0),
+        GATHERING_INFO(200),
+        CLEAR_COMPLETE(201);
+
+        private final int code;
+        StatusCodes(int code) { this.code = code; }
+        public int getCode() { return code; }
+    }
+    public enum ErrorCodes {
+        INVALID_ARGUMENTS(100),
+        PROCESS_TIMED_OUT(101),
+        CANCELLED_BY_USER(102),
+        INVALID_API_KEY(103),
+        VERIFY_API_KEY_FAIL(104);
+
+        private final int code;
+        ErrorCodes(int code) { this.code = code; }
+        public int getCode() { return code; }
+    }
+
+    // argument indexes from Cordova javascript
     final int BlinkUpArgumentApiKey = 0;
     final int BlinkUpArgumentDeveloperPlanId = 1;
     final int BlinkUpArgumentTimeOut = 2;
     final int BlinkUpUsedCachedPlanId = 3;
-
-    public static final int DEVICE_CONNECTED = 0;
-    public static final int GATHERING_INFO = 200;
-    public static final int CLEAR_COMPLETE = 201;
-
-    public static final int INVALID_ARGUMENTS = 100;
-    public static final int PROCESS_TIMED_OUT = 101;
-    public static final int CANCELLED_BY_USER = 102;
-    public static final int INVALID_API_KEY = 103;
-    public static final int VERIFY_API_KEY_FAIL = 104;
 
     /**********************************************************
      * method called by Cordova javascript
@@ -69,12 +81,12 @@ public class BlinkUpPlugin extends CordovaPlugin {
             try {
                 this.apiKey = data.getString(BlinkUpArgumentApiKey);
                 this.developerPlanId = data.getString(BlinkUpArgumentDeveloperPlanId);
-                this.timeoutMs = data.getInt(BlinkUpArgumentTimeOut);
+                timeoutMs = data.getInt(BlinkUpArgumentTimeOut);
                 this.useCachedPlanId = data.getBoolean(BlinkUpUsedCachedPlanId);
             } catch (JSONException exc) {
                 BlinkUpPluginResult pluginResult = new BlinkUpPluginResult();
                 pluginResult.setState(BlinkUpPluginResult.BlinkUpPluginState.Error);
-                pluginResult.setPluginError(this.INVALID_ARGUMENTS);
+                pluginResult.setPluginError(ErrorCodes.INVALID_ARGUMENTS.getCode());
                 pluginResult.sendResultsToCallback();
                 return false;
             }
@@ -107,7 +119,7 @@ public class BlinkUpPlugin extends CordovaPlugin {
                     Toast.makeText(cordova.getActivity(), "Error. Invalid BlinkUp API key.", Toast.LENGTH_LONG).show();
                     BlinkUpPluginResult pluginResult = new BlinkUpPluginResult();
                     pluginResult.setState(BlinkUpPluginResult.BlinkUpPluginState.Error);
-                    pluginResult.setPluginError(INVALID_API_KEY);
+                    pluginResult.setPluginError(ErrorCodes.INVALID_API_KEY.getCode());
                     pluginResult.sendResultsToCallback();
                 }
                 else {
@@ -122,7 +134,7 @@ public class BlinkUpPlugin extends CordovaPlugin {
             public void onError(String s) {
                 BlinkUpPluginResult pluginResult = new BlinkUpPluginResult();
                 pluginResult.setState(BlinkUpPluginResult.BlinkUpPluginState.Error);
-                pluginResult.setStatusCode(VERIFY_API_KEY_FAIL);
+                pluginResult.setStatusCode(ErrorCodes.VERIFY_API_KEY_FAIL.getCode());
                 pluginResult.sendResultsToCallback();
             }
         };

--- a/platforms/android/src/com/macadamian/blinkup/BlinkUpPluginResult.java
+++ b/platforms/android/src/com/macadamian/blinkup/BlinkUpPluginResult.java
@@ -53,34 +53,48 @@ public class BlinkUpPluginResult {
 
     // possible states
     public enum BlinkUpPluginState {
-        Started,
-        Completed,
-        Error
+        Started("started"),
+        Completed("completed"),
+        Error("error");
+
+        private final String state;
+        BlinkUpPluginState(String state) { this.state = state; }
+        public String getKey() { return this.state; }
     }
 
-    // error types
+    // possible error types
     private enum BlinkUpErrorType {
-        BlinkUpSDKError,
-        PluginError
+        BlinkUpSDKError("blinkup"),
+        PluginError("plugin");
+
+        private final String type;
+        BlinkUpErrorType(String type) { this.type = type; }
+        public String getType() { return this.type; }
     }
 
     //=====================================
     // JSON keys for results
     //=====================================
-    // keys for JSON sent back to javascript
-    private static final String STATE_KEY = "state";
-    private static final String STATUS_CODE_KEY = "statusCode";
+    private enum ResultKeys {
+        STATE("state"),
+        STATUS_CODE("statusCode"),
 
-    private static final String ERROR_KEY = "error";
-    private static final String ERROR_TYPE_KEY = "errorType";
-    private static final String ERROR_CODE_KEY = "errorCode";
-    private static final String ERROR_MSG_KEY = "errorMsg";
+        ERROR("error"),
+        ERROR_TYPE("errorType"),
+        ERROR_CODE("errorCode"),
+        ERROR_MSG("errorMsg"),
 
-    private static final String DEVICE_INFO_KEY = "deviceInfo";
-    private static final String DEVICE_ID_KEY = "deviceId";
-    private static final String PLAN_ID_KEY = "planId";
-    private static final String AGENT_URL_KEY = "agentURL";
-    private static final String VERIFICATION_DATE_KEY = "verificationDate";
+        DEVICE_INFO("deviceInfo"),
+        DEVICE_ID("deviceId"),
+        PLAN_ID("planId"),
+        AGENT_URL("agentURL"),
+        VERIFICATION_DATE("verificationDate");
+
+        private final String key;
+        ResultKeys(String key) { this.key = key; }
+        public String getKey() { return this.key; }
+
+    }
 
     //====================================
     // BlinkUp Results
@@ -140,44 +154,34 @@ public class BlinkUpPluginResult {
 
         try {
             // set our state (never null)
-            if (this.state == BlinkUpPluginState.Started) {
-                resultJSON.put(this.STATE_KEY, "started");
-            } else if (this.state == BlinkUpPluginState.Completed) {
-                resultJSON.put(this.STATE_KEY, "completed");
-            } else {
-                resultJSON.put(this.STATE_KEY, "error");
-            }
+            resultJSON.put(ResultKeys.STATE.getKey(), this.state.getKey());
 
             // error
             if (this.state == BlinkUpPluginState.Error) {
                 JSONObject errorJson = new JSONObject();
-                if (this.errorType == BlinkUpErrorType.BlinkUpSDKError) {
-                    errorJson.put(this.ERROR_TYPE_KEY, "blinkup");
-                    errorJson.put(this.ERROR_MSG_KEY, this.errorMsg);
+                errorJson.put(ResultKeys.ERROR_CODE.getKey(), String.valueOf(this.errorCode));
+                if (this.errorMsg != null) {
+                    errorJson.put(ResultKeys.ERROR_MSG.getKey(), this.errorMsg);
                 }
-                else {
-                    errorJson.put(this.ERROR_TYPE_KEY, "plugin");
-                }
-                errorJson.put(this.ERROR_CODE_KEY, String.valueOf(this.errorCode));
-                resultJSON.put(this.ERROR_KEY, errorJson);
+                resultJSON.put(ResultKeys.ERROR.getKey(), errorJson);
             }
 
             // success
             else {
-                resultJSON.put(this.STATUS_CODE_KEY, String.valueOf(statusCode));
+                resultJSON.put(ResultKeys.STATUS_CODE.getKey(), String.valueOf(statusCode));
 
                 if (this.deviceId != null && this.planId != null
                  && this.agentURL != null && this.verificationDate != null) {
                     JSONObject deviceInfoJson = new JSONObject();
-                    deviceInfoJson.put(this.DEVICE_ID_KEY, this.deviceId);
-                    deviceInfoJson.put(this.PLAN_ID_KEY, this.planId);
-                    deviceInfoJson.put(this.AGENT_URL_KEY, this.agentURL);
-                    deviceInfoJson.put(this.VERIFICATION_DATE_KEY, this.verificationDate);
-                    resultJSON.put(this.DEVICE_INFO_KEY, deviceInfoJson);
+                    deviceInfoJson.put(ResultKeys.DEVICE_ID.getKey(), this.deviceId);
+                    deviceInfoJson.put(ResultKeys.PLAN_ID.getKey(), this.planId);
+                    deviceInfoJson.put(ResultKeys.AGENT_URL.getKey(), this.agentURL);
+                    deviceInfoJson.put(ResultKeys.VERIFICATION_DATE.getKey(), this.verificationDate);
+                    resultJSON.put(ResultKeys.DEVICE_INFO.getKey(), deviceInfoJson);
                 }
             }
         } catch (JSONException e) {
-            Log.e("BlinkUpPlugin", "Error creating result JSOn.");
+            Log.e("BlinkUpPlugin", "Error creating result JSON.");
             e.printStackTrace();
         }
 

--- a/platforms/android/src/com/macadamian/blinkup/ClearCompleteActivity.java
+++ b/platforms/android/src/com/macadamian/blinkup/ClearCompleteActivity.java
@@ -35,7 +35,7 @@ public class ClearCompleteActivity extends Activity {
         // send callback that we've cleared device
         BlinkUpPluginResult pluginResult = new BlinkUpPluginResult();
         pluginResult.setState(BlinkUpPluginResult.BlinkUpPluginState.Completed);
-        pluginResult.setStatusCode(BlinkUpPlugin.CLEAR_COMPLETE);
+        pluginResult.setStatusCode(BlinkUpPlugin.StatusCodes.CLEAR_COMPLETE.getCode());
         pluginResult.sendResultsToCallback();
 
         this.finish();


### PR DESCRIPTION
-unable to have base string values in Objective-C enum, so only able to do this in android
-less hardcoded strings on android as a result
