### PR TITLE
Rename useCachedPlanId in js interface to match native implementation (rename-use-cached-planid)

### DIFF
--- a/platforms/ios/CordovaBlinkUpSample/Plugins/com.macadamian.blinkup/BlinkUpPlugin.m
+++ b/platforms/ios/CordovaBlinkUpSample/Plugins/com.macadamian.blinkup/BlinkUpPlugin.m
@@ -118,7 +118,7 @@ typedef NS_ENUM(NSInteger, BlinkupArguments) {
         planId = (self.developerPlanId != "") ? self.developerPlanId : nil;
     #endif
     
-    if (self.generatePlanId || planId != nil) {
+    if (self.generatePlanId || planId == nil) {
         self.blinkUpController = [[BUBasicController alloc] initWithApiKey:self.apiKey];
     }
     else {

--- a/www/js/blinkup.js
+++ b/www/js/blinkup.js
@@ -19,9 +19,9 @@
 /*global cordova, module*/
 
 module.exports = {
-    //apiKey: string, developerPlanId: string, timeoutMs: int, useCachedPlanId: bool 
-    invokeBlinkUp: function (apiKey, developerPlanId, timeoutMs, useCachedPlanId, successCallback, errorCallback) {
-        cordova.exec(successCallback, errorCallback, "BlinkUpPlugin", "invokeBlinkUp", [apiKey, developerPlanId, timeoutMs, useCachedPlanId]);
+    //apiKey: string, developerPlanId: string, timeoutMs: int, generatePlanId: bool 
+    invokeBlinkUp: function (apiKey, developerPlanId, timeoutMs, generatePlanId, successCallback, errorCallback) {
+        cordova.exec(successCallback, errorCallback, "BlinkUpPlugin", "invokeBlinkUp", [apiKey, developerPlanId, timeoutMs, generatePlanId]);
     },
     abortBlinkUp: function (successCallback, errorCallback) {
         cordova.exec(successCallback, errorCallback, "BlinkUpPlugin", "abortBlinkUp", []);

--- a/www/js/index.js
+++ b/www/js/index.js
@@ -70,7 +70,7 @@ var app = {
         // Perform Blinkup ---------------------------------------
         var blinkupBtn = document.getElementById('blinkup-button');
         blinkupBtn.addEventListener('click', function () {
-            blinkup.invokeBlinkUp(apiKey, planId, timeoutMs, true, blinkUpCallback, blinkUpCallback);
+            blinkup.invokeBlinkUp(apiKey, planId, timeoutMs, false, blinkUpCallback, blinkUpCallback);
         });
 
         // Clear Wifi & Cached PlanId ----------------------------

--- a/www/plugins/com.macadamian.blinkup/www/blinkup.js
+++ b/www/plugins/com.macadamian.blinkup/www/blinkup.js
@@ -18,9 +18,9 @@
 
 cordova.define("com.macadamian.blinkup.blinkup", function(require, exports, module) { 
     module.exports = {
-        //apiKey: string, developerPlanId: string, timeoutMs: int, useCachedPlanId: bool 
-        invokeBlinkUp: function (apiKey, developerPlanId, timeoutMs, useCachedPlanId, successCallback, errorCallback) {
-            cordova.exec(successCallback, errorCallback, "BlinkUpPlugin", "invokeBlinkUp", [apiKey, developerPlanId, timeoutMs, useCachedPlanId]);
+        //apiKey: string, developerPlanId: string, timeoutMs: int, generatePlanId: bool 
+        invokeBlinkUp: function (apiKey, developerPlanId, timeoutMs, generatePlanId, successCallback, errorCallback) {
+            cordova.exec(successCallback, errorCallback, "BlinkUpPlugin", "invokeBlinkUp", [apiKey, developerPlanId, timeoutMs, generatePlanId]);
         },
         abortBlinkUp: function (successCallback, errorCallback) {
             cordova.exec(successCallback, errorCallback, "BlinkUpPlugin", "abortBlinkUp", []);


### PR DESCRIPTION
Switched to generatePlanId a couple commits ago in native, forgot to update interface.
