### PR TITLE
Revert "fixes issue where developer planId not being used on iOS"

### DIFF
--- a/platforms/ios/CordovaBlinkUpSample.xcodeproj/project.pbxproj
+++ b/platforms/ios/CordovaBlinkUpSample.xcodeproj/project.pbxproj
@@ -231,10 +231,10 @@
 			isa = PBXGroup;
 			children = (
 				A6ADB6371B43020300EDB117 /* Categories */,
-				770935509EF54A7DA7A3CF13 /* BlinkUpPluginResult.h */,
+				811DAE0CE5044B53BB98FEBF /* BlinkUpPlugin.m */,
 				3AF1BF558079461E8BC0A43D /* BlinkUpPluginResult.m */,
 				405FE7EC9E1C4EDA89481AF7 /* BlinkUpPlugin.h */,
-				811DAE0CE5044B53BB98FEBF /* BlinkUpPlugin.m */,
+				770935509EF54A7DA7A3CF13 /* BlinkUpPluginResult.h */,
 			);
 			name = Plugins;
 			path = CordovaBlinkUpSample/Plugins;
@@ -282,8 +282,8 @@
 		A6ADB6371B43020300EDB117 /* Categories */ = {
 			isa = PBXGroup;
 			children = (
-				066C63F6EFF64575B026781C /* BUDeviceInfo+JSON.h */,
 				5DA0DE9341784F0EBF5920A2 /* BUDeviceInfo+JSON.m */,
+				066C63F6EFF64575B026781C /* BUDeviceInfo+JSON.h */,
 			);
 			name = Categories;
 			sourceTree = "<group>";
@@ -473,7 +473,6 @@
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "CordovaBlinkUpSample/CordovaBlinkUpSample-Prefix.pch";
-				GCC_PREPROCESSOR_DEFINITIONS = "DEBUG=1";
 				GCC_THUMB_SUPPORT = NO;
 				GCC_VERSION = "";
 				INFOPLIST_FILE = "CordovaBlinkUpSample/CordovaBlinkUpSample-Info.plist";

--- a/platforms/ios/CordovaBlinkUpSample/Plugins/com.macadamian.blinkup/BlinkUpPlugin.m
+++ b/platforms/ios/CordovaBlinkUpSample/Plugins/com.macadamian.blinkup/BlinkUpPlugin.m
@@ -114,13 +114,9 @@ typedef NS_ENUM(NSInteger, BlinkupArguments) {
     // load cached planID (if not cached yet, BlinkUp automatically generates a new one)
     NSString *planId = [[NSUserDefaults standardUserDefaults] objectForKey:PLAN_ID_CACHE_KEY];
 
-    // If running with debug build configuration, this will overwrite the planId from the cache
-    // with the one passed from Javascript. If empty string passed, a new planId will be generated.
-    //
-    // IMPORTANT NOTE: if a developer planId makes it into production, the device will NOT connect.
-    // See electricimp.com/docs/manufacturing/planids/ for more info about planIDs
+    // see electricimp.com/docs/manufacturing/planids/ for info about planIDs
     #ifdef DEBUG
-        planId = ([self.developerPlanId length] > 0) ? self.developerPlanId : nil;
+        planId = (self.developerPlanId != "") ? self.developerPlanId : nil;
     #endif
     
     if (self.generatePlanId || planId == nil) {


### PR DESCRIPTION
Reverts Macadamian/Cordova-BlinkUpSample#46

Forgot - this needs to be fixed in the other repo. Same thing with my fix.
