### PR TITLE
Critical Bug: PlanId not updated to developerPlanId in invokeBlinkUp.

### DIFF
--- a/www/js/index.js
+++ b/www/js/index.js
@@ -82,7 +82,7 @@ var app = {
         // Perform Blinkup ---------------------------------------
         var blinkupBtn = document.getElementById('blinkup-button');
         blinkupBtn.addEventListener('click', function () {
-            blinkup.invokeBlinkUp(apiKey, planId, timeoutMs, false, blinkUpCallback, blinkUpCallback);
+            blinkup.invokeBlinkUp(apiKey, developerPlanId, timeoutMs, false, blinkUpCallback, blinkUpCallback);
         });
 
         // Clear Wifi & Cached PlanId ----------------------------


### PR DESCRIPTION
Symptom: Objective-C plugin actually sees collection instead of string.
Fix: passing in the correct plan id.
Tested:
- blinkup, clear blinkup. relaunch of the application after successful blinkup.
- launch application without developer plan id.
