### PR TITLE
Revert "62 Android: application can go to landscape"

### DIFF
--- a/platforms/android/AndroidManifest.xml
+++ b/platforms/android/AndroidManifest.xml
@@ -1,36 +1,11 @@
 <?xml version='1.0' encoding='utf-8'?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.macadamian.CordovaBlinkUpSample"
-    android:hardwareAccelerated="true"
-    android:versionCode="1"
-    android:versionName="0.5">
-
-    <supports-screens
-        android:anyDensity="true"
-        android:largeScreens="true"
-        android:normalScreens="true"
-        android:resizeable="true"
-        android:smallScreens="true"
-        android:xlargeScreens="true" />
-
+<manifest android:hardwareAccelerated="true" android:versionCode="1" android:versionName="0.0.1" package="com.macadamian.CordovaBlinkUpSample" xmlns:android="http://schemas.android.com/apk/res/android">
+    <supports-screens android:anyDensity="true" android:largeScreens="true" android:normalScreens="true" android:resizeable="true" android:smallScreens="true" android:xlargeScreens="true" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
-
-    <application
-        android:hardwareAccelerated="true"
-        android:icon="@drawable/icon"
-        android:label="@string/app_name"
-        android:supportsRtl="true"
-        android:theme="@android:style/Theme.Holo.Light">
-        <activity
-            android:name="MainActivity"
-            android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale"
-            android:label="@string/activity_name"
-            android:launchMode="singleTop"
-            android:screenOrientation="portrait"
-            android:theme="@android:style/Theme.Black.NoTitleBar"
-            android:windowSoftInputMode="adjustResize">
+    <application android:hardwareAccelerated="true" android:icon="@drawable/icon" android:label="@string/app_name" android:supportsRtl="true" android:theme="@android:style/Theme.Holo.Light">
+        <activity android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale" android:label="@string/activity_name" android:launchMode="singleTop" android:name="MainActivity" android:theme="@android:style/Theme.Black.NoTitleBar" android:windowSoftInputMode="adjustResize">
             <intent-filter android:label="@string/launcher_name">
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
@@ -38,33 +13,13 @@
         </activity>
         <activity android:name="com.macadamian.blinkup.ClearCompleteActivity" />
         <activity android:name="com.macadamian.blinkup.BlinkUpCompleteActivity" />
-        <activity
-            android:name="com.electricimp.blinkup.WifiSelectActivity"
-            android:label="BlinkUp"
-            android:screenOrientation="portrait" />
-        <activity
-            android:name="com.electricimp.blinkup.BlinkupGLActivity"
-            android:label="BlinkUp"
-            android:screenOrientation="portrait" />
-        <activity
-            android:name="com.electricimp.blinkup.WifiActivity"
-            android:label="BlinkUp"
-            android:screenOrientation="portrait" />
-        <activity
-            android:name="com.electricimp.blinkup.WPSActivity"
-            android:label="BlinkUp"
-            android:screenOrientation="portrait" />
-        <activity
-            android:name="com.electricimp.blinkup.ClearWifiActivity"
-            android:label="BlinkUp"
-            android:screenOrientation="portrait" />
-        <activity
-            android:name="com.electricimp.blinkup.InterstitialActivity"
-            android:label="BlinkUp"
-            android:screenOrientation="portrait" />
+        <activity android:label="BlinkUp" android:name="com.electricimp.blinkup.WifiSelectActivity" />
+        <activity android:label="BlinkUp" android:name="com.electricimp.blinkup.BlinkupGLActivity" />
+        <activity android:label="BlinkUp" android:name="com.electricimp.blinkup.WifiActivity" />
+        <activity android:label="BlinkUp" android:name="com.electricimp.blinkup.WPSActivity" />
+        <activity android:label="BlinkUp" android:name="com.electricimp.blinkup.ClearWifiActivity" />
+        <activity android:label="BlinkUp" android:name="com.electricimp.blinkup.InterstitialActivity" />
     </application>
-    <uses-sdk
-        android:minSdkVersion="11"
-        android:targetSdkVersion="22" />
+    <uses-sdk android:minSdkVersion="11" android:targetSdkVersion="22" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
 </manifest>


### PR DESCRIPTION
When updating the plugin code, cordova doesn't like the orientation
param for its activities and duplicates them, thereby garbling the
manifest.

Changelog:
- revert the change

Tests:
- Verified updating the plugin code does't break the build by garbling
  the manifest
