### PR TITLE
force portait orientation only

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -21,6 +21,7 @@
     <allow-intent href="sms:*" />
     <allow-intent href="mailto:*" />
     <allow-intent href="geo:*" />
+    <preference name="orientation" value="portrait" />  
     <platform name="android">
         <allow-intent href="market:*" />
     </platform>


### PR DESCRIPTION
- sets orientation to portrait in config.xml
- testing: tested on emulator (Android 5.0) and device (4.2.1) and rotating didn't change orientation (expected)
- note: JPL tested on his device and it did rotate to landscape (unexpected), not sure why it's different
