### PR TITLE
Ux feedback - Button Ordering

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -76,7 +76,7 @@
                     </div>
                 </div>
                 <div class="device-info-header">
-                    Device Info:
+                    Paired Device:
                 </div>
                 <ul class="device-info">
                     <li>
@@ -98,8 +98,8 @@
                 </ul>
                 <div class="actions">
                     <div id="abort-button" class="m-button" style="display: none;">Cancel BlinkUp</div>
-                    <div id="clear-button" class="m-button">Clear Wifi &amp; Cache</div>
-                    <div id="blinkup-button" class="m-button">Perform BlinkUp</div>
+                    <div id="blinkup-button" class="m-button">Pair with BlinkUp</div>
+                    <div id="clear-button" class="m-button">Unpair with BlinkUp &amp; Clear Cache</div>
                 </div>
                 <br/><br/>
             </div>


### PR DESCRIPTION
Logically someone would perform a blinkup before clearing.

Fix:
Put the perform Blinkup button on top of clear.

Tested:
iOS + Android: testing that the buttons operate as expected.
