### PR TITLE
Issue: iOS landscape rendering issue post-blinkup.

### DIFF
--- a/platforms/ios/CordovaBlinkUpSample/Classes/AppDelegate.m
+++ b/platforms/ios/CordovaBlinkUpSample/Classes/AppDelegate.m
@@ -130,8 +130,6 @@
 {
     // iPhone doesn't support upside down by default, while the iPad does.  Override to allow all orientations always, and let the root view controller decide what's allowed (the supported orientations mask gets intersected).
     return (1 << UIInterfaceOrientationPortrait) |
-           (1 << UIInterfaceOrientationLandscapeLeft) |
-           (1 << UIInterfaceOrientationLandscapeRight) |
            (1 << UIInterfaceOrientationPortraitUpsideDown);
 
 }


### PR DESCRIPTION
Cause: iOS still tolerated landscape mode, while the application doesn't fully support it.
Fix: disabled landscape mode entirely.
